### PR TITLE
Make poller logs verbose

### DIFF
--- a/common/poller.js
+++ b/common/poller.js
@@ -31,7 +31,7 @@ module.exports = function (opts, callback) {
         fs.readFile(opts.filePath, 'utf8',
           function (err, data) {
             if (err)
-              logger.warn(
+              logger.verbose(
                 util.format('%s: failed to read file: %s with error: %s',
                   who, opts.filePath, err
                 )


### PR DESCRIPTION
If there is no build running, this will emit warn logs every 5 seconds.
This is unnecessary noise.

https://github.com/Shippable/reqKick/issues/41